### PR TITLE
Add cluster_name property to avoid several clusters merging accidentally

### DIFF
--- a/scuttlebutt-test/src/lib.rs
+++ b/scuttlebutt-test/src/lib.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ApiResponse {
+    pub cluster_name: String,
     pub cluster_state: SerializableClusterState,
     pub live_nodes: Vec<NodeId>,
     pub dead_nodes: Vec<NodeId>,

--- a/scuttlebutt-test/src/main.rs
+++ b/scuttlebutt-test/src/main.rs
@@ -40,6 +40,7 @@ impl Api {
     async fn index(&self) -> Json<serde_json::Value> {
         let scuttlebutt_guard = self.scuttlebutt.lock().await;
         let response = ApiResponse {
+            cluster_name: scuttlebutt_guard.cluster_name().to_string(),
             cluster_state: SerializableClusterState::from(scuttlebutt_guard.cluster_state()),
             live_nodes: scuttlebutt_guard.live_nodes().cloned().collect::<Vec<_>>(),
             dead_nodes: scuttlebutt_guard.dead_nodes().cloned().collect::<Vec<_>>(),
@@ -67,6 +68,7 @@ async fn main() -> Result<(), std::io::Error> {
         NodeId::from(opt.listen_addr.as_str()),
         &opt.seeds[..],
         &opt.listen_addr,
+        "testing".to_string(),
         Vec::<(&str, &str)>::new(),
         FailureDetectorConfig::default(),
     );

--- a/scuttlebutt-test/tests/cli.rs
+++ b/scuttlebutt-test/tests/cli.rs
@@ -78,6 +78,7 @@ fn test_multiple_nodes() -> anyhow::Result<()> {
         .node_states
         .get("localhost:10003")
         .is_some());
+    assert_eq!(info.cluster_name, "testing");
     assert_eq!(info.live_nodes.len(), 4);
     assert_eq!(info.dead_nodes.len(), 0);
 

--- a/scuttlebutt/src/digest.rs
+++ b/scuttlebutt/src/digest.rs
@@ -27,7 +27,7 @@ use crate::{NodeId, Version};
 ///
 /// It is equivalent to a map
 /// peer -> max version.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct Digest {
     pub(crate) node_max_version: BTreeMap<NodeId, Version>,
 }

--- a/scuttlebutt/src/lib.rs
+++ b/scuttlebutt/src/lib.rs
@@ -186,7 +186,7 @@ impl ScuttleButt {
             } => {
                 if cluster_name != self.cluster_name {
                     warn!(
-                        cluster_name = ?cluster_name,
+                        cluster_name = %cluster_name,
                         "rejecting syn message with mismatching cluster name"
                     );
                     return Some(ScuttleButtMessage::BadCluster);

--- a/scuttlebutt/src/lib.rs
+++ b/scuttlebutt/src/lib.rs
@@ -187,9 +187,9 @@ impl ScuttleButt {
                 if cluster_name != self.cluster_name {
                     warn!(
                         cluster_name = ?cluster_name,
-                        "ignoring syn message with mismatching cluster name"
+                        "rejecting syn message with mismatching cluster name"
                     );
-                    return None;
+                    return Some(ScuttleButtMessage::BadCluster);
                 }
 
                 let self_digest = self.compute_digest();
@@ -217,6 +217,10 @@ impl ScuttleButt {
             ScuttleButtMessage::Ack { delta } => {
                 self.report_to_failure_detector(&delta);
                 self.cluster_state.apply_delta(delta);
+                None
+            }
+            ScuttleButtMessage::BadCluster => {
+                warn!("message rejected by peer: cluster name mismatch");
                 None
             }
         }

--- a/scuttlebutt/src/server.rs
+++ b/scuttlebutt/src/server.rs
@@ -63,6 +63,7 @@ impl ScuttleServer {
         node_id: NodeId,
         seed_nodes: &[String],
         address: impl Into<String>,
+        cluster_name: String,
         initial_key_values: Vec<(impl ToString, impl ToString)>,
         failure_detector_config: FailureDetectorConfig,
     ) -> Self {
@@ -72,6 +73,7 @@ impl ScuttleServer {
             node_id,
             seed_nodes.iter().cloned().collect(),
             address.into(),
+            cluster_name,
             initial_key_values,
             failure_detector_config,
         );
@@ -96,7 +98,9 @@ impl ScuttleServer {
 
     /// Call a function with mutable access to the [`ScuttleButt`].
     pub async fn with_scuttlebutt<F, T>(&self, mut fun: F) -> T
-    where F: FnMut(&mut ScuttleButt) -> T {
+    where
+        F: FnMut(&mut ScuttleButt) -> T,
+    {
         let mut scuttlebutt = self.scuttlebutt.lock().await;
         fun(&mut scuttlebutt)
     }
@@ -397,6 +401,7 @@ mod tests {
             "0.0.0.0:1112".into(),
             &[],
             "0.0.0.0:1112",
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -422,6 +427,7 @@ mod tests {
             "offline".into(),
             HashSet::new(),
             "offline".to_string(),
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -430,6 +436,7 @@ mod tests {
             server_addr.into(),
             &[],
             server_addr,
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -458,6 +465,7 @@ mod tests {
             server_addr.into(),
             &[],
             server_addr,
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -466,6 +474,7 @@ mod tests {
             "offline".into(),
             HashSet::new(),
             "offline".to_string(),
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -497,6 +506,7 @@ mod tests {
             server_addr.into(),
             &[],
             server_addr,
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -505,6 +515,7 @@ mod tests {
             "offline".into(),
             HashSet::new(),
             "offline".to_string(),
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -537,6 +548,7 @@ mod tests {
             "0.0.0.0:5552".into(),
             &[server_addr.into()],
             "0.0.0.0:5552",
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -559,6 +571,7 @@ mod tests {
             test_addr.into(),
             HashSet::new(),
             test_addr.to_string(),
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -570,6 +583,7 @@ mod tests {
             NodeId::from(server_addr),
             &[],
             server_addr,
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -617,6 +631,7 @@ mod tests {
             NodeId::from("0.0.0.0:6663"),
             &[],
             "0.0.0.0:6663",
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );
@@ -624,6 +639,7 @@ mod tests {
             NodeId::from("0.0.0.0:6664"),
             &["0.0.0.0:6663".to_string()],
             "0.0.0.0:6664",
+            "test-cluster".to_string(),
             Vec::<(&str, &str)>::new(),
             FailureDetectorConfig::default(),
         );


### PR DESCRIPTION
As described in https://github.com/quickwit-oss/quickwit/pull/1260, we need a mechanism to ensure clusters do not accidentally merge when IPs are reused.

This PR:

- introduces a required `cluster_name` argument when setting up the cluster
- adds that cluster name to outgoing `Syn` messages
- adds a `BadCluster` message type
- if the cluster name in the `Syn` message does not match the peer's cluster name, a `BadCluster` message is returned instead of a `SynAck`

## Additional notes

- This PR changes the wire format, but I did not see any versioning mechanism in the protocol. We should merge this before v0.3 is released, to sidestep any compatibility issue.